### PR TITLE
chore: marking action as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Verimatrix XTD and Counterspy
+# Verimatrix XTD and Counterspy [DEPRECATED]
+
+⚠️ **DEPRECATED** ⚠️
+This action is deprecated and will no longer be maintained. Please use
+the [vmx-aps - APS command line wrapper](https://pypi.org/project/vmx-aps/) instead.
 
 This action integrates Verimatrix Extended Threat Defense and Counterspy into your GitHub build workflow. It automates
 the protection of your Android and iOS apps so you can run it whenever a new version

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Verimatrix XTD and Counterspy [DEPRECATED]
-
+- - -
 ⚠️ **DEPRECATED** ⚠️
 This action is deprecated and will no longer be maintained. Please use
 the [vmx-aps - APS command line wrapper](https://pypi.org/project/vmx-aps/) instead.
-
+- - - 
 This action integrates Verimatrix Extended Threat Defense and Counterspy into your GitHub build workflow. It automates
 the protection of your Android and iOS apps so you can run it whenever a new version
 of your application is built.

--- a/action.yml
+++ b/action.yml
@@ -7,18 +7,23 @@ branding:
 inputs:
   api-key-secret:
     description: 'API Key Secret'
+    deprecationMessage: 'This GH action is deprecated. Please use APS command line wrapper directly https://pypi.org/project/vmx-aps/'
     required: true
   api-gateway-url:
     description: 'Optional API Gateway URL'
+    deprecationMessage: 'This GH action is deprecated. Please use APS command line wrapper directly https://pypi.org/project/vmx-aps/'
     required: false
   access-token-url:
     description: 'Optional Access Token URL'
+    deprecationMessage: 'This GH action is deprecated. Please use APS command line wrapper directly https://pypi.org/project/vmx-aps/'
     required: false
   subscription-type:
     description: 'Optional Subscription Type'
+    deprecationMessage: 'This GH action is deprecated. Please use APS command line wrapper directly https://pypi.org/project/vmx-aps/'
     required: false
   app-file:
     description: 'Mobile application file'
+    deprecationMessage: 'This GH action is deprecated. Please use APS command line wrapper directly https://pypi.org/project/vmx-aps/'
     required: true
 
 outputs:


### PR DESCRIPTION
Deprecated GH action. 
vmx-aps - APS command line wrapper should be used instead. https://pypi.org/project/vmx-aps/